### PR TITLE
Tagging Issues

### DIFF
--- a/App-Repositorio/lib/App/Repositorio/Plugin/Base.pm
+++ b/App-Repositorio/lib/App/Repositorio/Plugin/Base.pm
@@ -374,6 +374,25 @@ sub tag {
 
   # handle symlink destination
   else {
+    # ensure the parent directory of the symlink exists
+    #Is there a nicer way to right this without resorting to multiple operations on the variable?
+    #Basically, it splits the dest_dir into parts, and then catdirs all the components except the last one.
+    my $dest_dir_parent = File::Spec->catdir(
+      ( splice( @{[ File::Spec->splitdir( $o{'dest_dir'} ) ]}, 0, -1 ) )
+    );
+
+    unless ( -d $dest_dir_parent ) {
+      $self->logger->log_and_die(
+        level   => 'error',
+        message => sprintf(
+          "tag; repo: %s couldnt create parent dir for link dst_dir: %s: $!",
+          $self->repo(), $o{'dest_dir'}
+        ),
+      ) unless make_path($dest_dir_parent) and -d $dest_dir_parent;
+
+
+    }
+
     if ( symlink $o{'src_dir'}, $o{'dest_dir'} ) {
       $self->logger->debug(
         sprintf(

--- a/App-Repositorio/lib/App/Repositorio/Plugin/Base.pm
+++ b/App-Repositorio/lib/App/Repositorio/Plugin/Base.pm
@@ -265,7 +265,7 @@ sub tag {
       dest_tag       => { type => SCALAR },
       dest_dir       => { type => SCALAR },
       symlink        => { type => BOOLEAN, default => 0 },
-      hard_tag_regex => { type => SCALAR, optional => 1 },
+      hard_tag_regex => { type => SCALAR | UNDEF, optional => 1 },
     }
   );
 


### PR DESCRIPTION
The validation for the plugin->tag() options fails if the option
'hard_tag_regex' evaluates to undef even though it is optional.  This
is due to the type validation being SCALAR which does not include UNDEF.

Adding UNDEF to the type validation list for the hard_tag_regex.
