### PR TITLE
Dont run createrepo against the Packages dir

### DIFF
--- a/App-Repositorio/lib/App/Repositorio/Plugin/Yum.pm
+++ b/App-Repositorio/lib/App/Repositorio/Plugin/Yum.pm
@@ -419,8 +419,7 @@ sub init_arch {
   }
 
   my @cmd = (
-    $createrepo_bin, '--basedir', $dir, '--outputdir', $dir,
-    $self->packages_dir()
+    $createrepo_bin, '--basedir', $dir, '--outputdir', $dir, $dir
   );
 
 # --update will reuse the existing metadata if the file is already defined and size/mtime matches


### PR DESCRIPTION
When init'ing repos (e.g local repos), createrepo needs to run against
the root of the repo (i.e. the dir that contains the 'Packages' and 'repodata' dirs)
otherwise the hrefs in the 'primary' DB are relative to the Packages dir and yum
cant find them.
